### PR TITLE
Factor the task runner out of Packager.

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,7 +15,6 @@
 package webpackager
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/google/webpackager/exchange"
@@ -31,17 +30,14 @@ const validityExt = ".validity"
 
 // Config defines injection points to Packager.
 type Config struct {
-	// RequestHeader specifies HTTP headers added to every request issued
-	// from Packager.
+	// RequestTweaker specifies the mutation applied to every http.Request
+	// before it is passed to FetchClient. RequestTweaker is applied
+	// both to the http.Request instances passed to the Packager and those
+	// generated internally (e.g. for subresources). Note that, however,
+	// some RequestTweakers have effect only to subresource requests.
 	//
-	// Note empty RequestHeader does not imply requests sent without any
-	// header fields: http.NewRequest sets a few headers automatically
-	// (such as "User-Agent"). RequestHeader takes the precedence over
-	// those automatic headers; setting their value to nil suppresses the
-	// automatic headers in particular.
-	//
-	// nil implies empty Header.
-	RequestHeader http.Header
+	// nil implies fetch.DefaultRequestTweaker.
+	RequestTweaker fetch.RequestTweaker
 
 	// FetchClient specifies how to retrieve the resources which Packager
 	// produces the signed exchanges for.
@@ -100,8 +96,8 @@ func (cfg *Config) populateDefaults() {
 	if cfg.ExchangeFactory == nil {
 		panic("ExchangeFactory can't be nil")
 	}
-	if cfg.RequestHeader == nil {
-		cfg.RequestHeader = make(http.Header)
+	if cfg.RequestTweaker == nil {
+		cfg.RequestTweaker = fetch.DefaultRequestTweaker
 	}
 	if cfg.FetchClient == nil {
 		cfg.FetchClient = fetch.DefaultFetchClient

--- a/doc.go
+++ b/doc.go
@@ -30,10 +30,9 @@ The code below illustrates the usage of this package:
 		}),
 	})
 	for _, url := range urls {
-		packager.Run(url)
-	}
-	if err := packager.Err(); err != nil {
-		log.Fatal(err)
+		if err := packager.Run(url); err != nil {
+			log.Print(err)
+		}
 	}
 
 Config allows you to change some behaviors of the Packager. packager.Run(url)

--- a/packager_test.go
+++ b/packager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/WICG/webpackage/go/signedexchange/version"
 	"github.com/google/webpackager"
 	"github.com/google/webpackager/exchange"
+	"github.com/google/webpackager/fetch"
 	"github.com/google/webpackager/fetch/fetchtest"
 	"github.com/google/webpackager/internal/certutil/certtest"
 	"github.com/google/webpackager/internal/urlutil"
@@ -150,7 +151,7 @@ func TestDupResource(t *testing.T) {
 	verifyExchange(t, pkg, "https://example.org/style.css", date, "")
 }
 
-func TestRequestHeader(t *testing.T) {
+func TestRequestTweaker(t *testing.T) {
 	handlers := http.NewServeMux()
 	handlers.Handle(
 		"example.org/hello.html",
@@ -169,7 +170,7 @@ func TestRequestHeader(t *testing.T) {
 	header.Set("User-Agent", dummyUA)
 
 	config := makeConfig(server)
-	config.RequestHeader = header
+	config.RequestTweaker = fetch.SetCustomHeaders(header)
 	pkg := webpackager.NewPackager(config)
 	pkg.Run(urlutil.MustParse("https://example.org/hello.html"),
 		exchange.NewValidPeriod(date, expires))

--- a/util.go
+++ b/util.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webpackager
+
+import (
+	"net/http"
+	"net/url"
+)
+
+func newGetRequest(url *url.URL) (*http.Request, error) {
+	// NOTE: We pass the error through to the caller, but this NewRequest
+	// call is expected always to succeed: method is http.MethodGet hence
+	// always valid; url is an already parsed value.
+	return http.NewRequest(http.MethodGet, url.String(), nil)
+}


### PR DESCRIPTION
The current design of Packager is a bit too optimized for batch processing, not convenient for on-demand processing (e.g. suppose Packager is used inside some server process). After this change,
Packager.Run will return error rather than accumulate it into a field. Packager will no longer prevent the same resource from being accessed multiple times in some cases, but will still cache signed exchanges and reuse them without making a server access. We can also write a wrapper around FetchClient to "cache" HTTP responses, when needed.