### PR TITLE
Add webpackager.Error.

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webpackager
+
+import (
+	"fmt"
+	"net/url"
+)
+// Error represents an error encountered in Packager.Run.
+type Error struct {
+	URL *url.URL
+	Err error
+}
+
+// WrapError wraps err into an Error.
+func WrapError(err error, url *url.URL) error {
+	if err == nil {
+		return nil
+	}
+	return &Error{url, err}
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return fmt.Sprintf("error with processing %s: %v", e.URL, e.Err)
+}
+
+// Unwrap returns the wrapped error.
+func (e *Error) Unwrap() error { return e.Err }

--- a/error.go
+++ b/error.go
@@ -18,18 +18,20 @@ import (
 	"fmt"
 	"net/url"
 )
-// Error represents an error encountered in Packager.Run.
+// Error represents an error from Packager.Run.
 type Error struct {
-	URL *url.URL
+	// Err represents the actual error.
 	Err error
+	// URL represents the URL that caused this Error.
+	URL *url.URL
 }
 
-// WrapError wraps err into an Error.
+// WrapError wraps err into an Error. url is the URL which err was raised for.
 func WrapError(err error, url *url.URL) error {
 	if err == nil {
 		return nil
 	}
-	return &Error{url, err}
+	return &Error{err, url}
 }
 
 // Error implements the error interface.

--- a/packager_test.go
+++ b/packager_test.go
@@ -213,10 +213,11 @@ func TestNoExchanges(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			url := urlutil.MustParse(test.url)
-
 			pkg := webpackager.NewPackager(makeConfig(server))
-			pkg.Run(url, exchange.NewValidPeriod(date, expires))
+			url := urlutil.MustParse(test.url)
+			err := pkg.Run(url, exchange.NewValidPeriod(date, expires))
+
+			verifyErrorURLs(t, err, []string{test.url})
 
 			req, err := http.NewRequest(http.MethodGet, test.url, nil)
 			if err != nil {

--- a/task.go
+++ b/task.go
@@ -75,7 +75,7 @@ func (runner *packagerTaskRunner) run(parent *packagerTask, req *http.Request, r
 	}
 
 	if err != nil {
-		err = fmt.Errorf("error with processing %s: %v", url, err)
+		err = WrapError(err, r.RequestURL)
 		runner.errs = multierror.Append(runner.errs, err)
 		log.Print(err)
 	}


### PR DESCRIPTION
With #10, it allows the caller to inspect the error from Packager and tell which URLs had errors.