### PR TITLE
Pass ValidPeriod to ValidityURLRule.Apply.

### DIFF
--- a/cmd/webpackager/flag_packager.go
+++ b/cmd/webpackager/flag_packager.go
@@ -152,12 +152,7 @@ func getPhysicalURLRuleFromFlags() (urlrewrite.Rule, error) {
 }
 
 func getValidityURLRuleFromFlags() (validity.ValidityURLRule, error) {
-	// err will be logged in getExchangeFactoryFromFlags().
-	date, err := parseDate(*flagDate)
-	if err != nil {
-		date = time.Now()
-	}
-	return validity.AppendExtDotUnixTime(*flagValidityExt, date), nil
+	return validity.AppendExtDotLastModified(*flagValidityExt), nil
 }
 
 func getExchangeFactoryFromFlags() (*exchange.Factory, error) {

--- a/config.go
+++ b/config.go
@@ -15,8 +15,6 @@
 package webpackager
 
 import (
-	"time"
-
 	"github.com/google/webpackager/exchange"
 	"github.com/google/webpackager/fetch"
 	"github.com/google/webpackager/processor"
@@ -25,8 +23,6 @@ import (
 	"github.com/google/webpackager/urlrewrite"
 	"github.com/google/webpackager/validity"
 )
-
-const validityExt = ".validity"
 
 // Config defines injection points to Packager.
 type Config struct {
@@ -106,7 +102,7 @@ func (cfg *Config) populateDefaults() {
 		cfg.PhysicalURLRule = urlrewrite.DefaultRules
 	}
 	if cfg.ValidityURLRule == nil {
-		cfg.ValidityURLRule = validity.AppendExtDotUnixTime(validityExt, time.Now())
+		cfg.ValidityURLRule = validity.DefaultValidityURLRule
 	}
 	if cfg.Processor == nil {
 		cfg.Processor = defaultproc.DefaultProcessor

--- a/task.go
+++ b/task.go
@@ -169,7 +169,7 @@ func (task *packagerTask) getPhysicalURL(r *resource.Resource, resp *http.Respon
 }
 
 func (task *packagerTask) getValidityURL(r *resource.Resource, resp *http.Response) (*url.URL, error) {
-	return task.ValidityURLRule.Apply(r.PhysicalURL, resp)
+	return task.ValidityURLRule.Apply(r.PhysicalURL, resp, task.period)
 }
 
 func (task *packagerTask) createExchange(rawResp *http.Response) (*signedexchange.Exchange, error) {

--- a/validity/url.go
+++ b/validity/url.go
@@ -60,11 +60,13 @@ var DefaultValidityURLRule ValidityURLRule = AppendExtDotLastModified(".validity
 // is missing or unparsable, AppendExtDotLastModified uses the date value
 // of the signed exchange signature (vp.Date).
 //
-// The returned ValidityURLRule does not accept physurl that looks like
-// a directory (e.g. has Path ending with a slash): Apply returns error
-// for such physurl. Note it does not occur if urlrewrite.IndexRule is
-// used. Also the rule does not expect physurl to have Query or Fragment:
-// Apply simply does not include in the validity URL.
+// The AppendExtDotLastModified rule does not support physurl that looks
+// like a directory (e.g. has Path ending with a slash). Apply returns an
+// error for such physurl. Note you can use urlrewrite.IndexRule to ensure
+// physurl to always have a filename.
+//
+// The AppendExtDotLastModified rule ignores Query and Fragment in physurl.
+// The validity URLs will always have empty Query and Fragment.
 func AppendExtDotLastModified(ext string) ValidityURLRule {
 	return &appendExtDotLastModified{ext}
 }
@@ -107,5 +109,6 @@ func toValidityURL(physurl *url.URL, ext string, date time.Time) (*url.URL, erro
 		return nil, fmt.Errorf("%q looks like a directory", physurl)
 	}
 	newPath := fmt.Sprintf("%s%s.%d", physurl.Path, ext, date.Unix())
+	// This ResolveReference drops Query and Fragment from the resulting URL.
 	return physurl.ResolveReference(&url.URL{Path: newPath}), nil
 }

--- a/validity/url_test.go
+++ b/validity/url_test.go
@@ -69,6 +69,18 @@ func TestAppendExtDotUnixTime(t *testing.T) {
 			want: "https://example.com/index.html.validity.1561939200",
 		},
 		{
+			name: "LastModified_QueryGone",
+			url:  "https://example.com/index.php?id=42",
+			header: http.Header{
+				"Last-Modified": []string{"Mon, 01 Jul 2019 12:34:56 GMT"},
+				"Content-Type":  []string{"text/html; charset=utf-8"},
+			},
+			rule: validity.AppendExtDotLastModified(".validity"),
+			vp: exchange.NewValidPeriodWithLifetime(
+				time.Unix(1561939200, 0), 24*time.Hour),
+			want: "https://example.com/index.php.validity.1561984496",
+		},
+		{
 			name: "ExchangeDate",
 			url:  "https://example.com/index.html",
 			header: http.Header{


### PR DESCRIPTION
AppendExtDotUnixTime (renamed to AppendExtDotLastModified) currently receives the current time via the constructor, but it does not fit to the case Packager is used like a server (i.e. runs intermittently).