### PR TITLE
Remove GO111MODULE=auto from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
 
 env:
-  - GO111MODULE=auto
   - GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ availability) at this moment.
 go get -u github.com/google/webpackager/cmd/...
 ```
 
+**Note:** Currently Web Packager compiles on Go 1.11+ but you need to enable
+    Go modules. On Go 1.11/1.12, you may require to set `GO111MODULE=on`.
+
 
 ## Usage
 


### PR DESCRIPTION
webpackager no longer compiles without Go modules: the latest version of github.com/hashicorp/go-multierror requires Go 1.14.