### PR TITLE
Split Config from exchange.Factory.

### DIFF
--- a/exchange/config.go
+++ b/exchange/config.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exchange
+
+import (
+	"crypto"
+	"net/url"
+
+	"github.com/WICG/webpackage/go/signedexchange/certurl"
+	"github.com/WICG/webpackage/go/signedexchange/version"
+	"github.com/google/webpackager/internal/urlutil"
+)
+
+// These are the default values in Config.
+const (
+	DefaultVersion      = version.Version1b3
+	DefaultMIRecordSize = 4096
+)
+
+// DefaultCertURL is the default value for CertURL in Config.
+var DefaultCertURL = urlutil.MustParse("/cert.cbor")
+
+// Config holds the parameters to produce signed exchanges.
+type Config struct {
+	// Version specifies the signed exchange version. If Version is empty,
+	// Factory uses DefaultVersion.
+	Version version.Version
+
+	// MIRecordSize specifies Merkle Integrity record size. The value must
+	// be positive, or zero to use DefaultMIRecordSize. It must not exceed
+	// 16384 (16 KiB) to be compliant with the specification.
+	MIRecordSize int
+
+	// CertChain specifies the certificate chain. CertChain may not be nil.
+	CertChain certurl.CertChain
+
+	// CertURL specifies the cert-url parameter in the signature. It can be
+	// relative, in which case Factory resolves the absolute URL using
+	// the request URL. It should still usually contain an absolute path
+	// (e.g. "/cert.cbor", not "cert.cbor"). If CertURL is nil, Factory uses
+	// DefaultCertURL.
+	CertURL *url.URL
+
+	// PrivateKey specifies the private key used for signing. PrivateKey may
+	// not be nil.
+	PrivateKey crypto.PrivateKey
+}
+
+func (c *Config) populateDefaults() {
+	if c.CertChain == nil {
+		panic("c.CertChain is nil")
+	}
+	if c.PrivateKey == nil {
+		panic("c.PrivateKey is nil")
+	}
+
+	if c.Version == "" {
+		c.Version = DefaultVersion
+	}
+	if c.MIRecordSize == 0 {
+		c.MIRecordSize = DefaultMIRecordSize
+	}
+	if c.CertURL == nil {
+		c.CertURL = DefaultCertURL
+	}
+}

--- a/exchange/factory.go
+++ b/exchange/factory.go
@@ -15,7 +15,6 @@
 package exchange
 
 import (
-	"crypto"
 	"errors"
 	"log"
 	"net/url"
@@ -23,22 +22,19 @@ import (
 	"time"
 
 	"github.com/WICG/webpackage/go/signedexchange"
-	"github.com/WICG/webpackage/go/signedexchange/certurl"
-	"github.com/WICG/webpackage/go/signedexchange/version"
 	"github.com/google/webpackager/internal/certutil"
 )
 
-// Factory holds the parameters to generate signed exchanges.
-//
-// CertURL can be relative, in which case Factory resolves the absolute URL
-// using the request URL. It should usually contain an absolute path though
-// (e.g. "/cert.cbor" rather than "cert.cbor").
+// Factory produces and verifies signed exchanges.
 type Factory struct {
-	Version      version.Version
-	MIRecordSize int
-	CertChain    certurl.CertChain
-	CertURL      *url.URL
-	PrivateKey   crypto.PrivateKey
+	Config
+}
+
+// NewFactory creates and initializes a new Factory. It panics if c.CertChain
+// or c.PrivateKey is nil.
+func NewFactory(c Config) *Factory {
+	c.populateDefaults()
+	return &Factory{c}
 }
 
 // NewExchange generates a signed exchange from resp, vp, and validityURL.

--- a/exchange/factory_test.go
+++ b/exchange/factory_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/WICG/webpackage/go/signedexchange/structuredheader"
-	"github.com/WICG/webpackage/go/signedexchange/version"
 	"github.com/google/webpackager/exchange"
 	"github.com/google/webpackager/exchange/exchangetest"
 	"github.com/google/webpackager/internal/certutil/certtest"
@@ -39,13 +38,11 @@ func eraseSignature(sxg []byte) []byte {
 
 func TestFactory(t *testing.T) {
 	// Initialize Factory with the parameters given to gen-signedexchange.
-	factory := &exchange.Factory{
-		Version:      version.Version1b3,
-		MIRecordSize: 4096,
-		CertChain:    certtest.ReadCertChainFile("../testdata/certs/test.cbor"),
-		CertURL:      urlutil.MustParse("https://example.org/cert.cbor"),
-		PrivateKey:   certtest.ReadPrivateKeyFile("../testdata/certs/test.key"),
-	}
+	factory := exchange.NewFactory(exchange.Config{
+		CertChain:  certtest.ReadCertChainFile("../testdata/certs/test.cbor"),
+		CertURL:    urlutil.MustParse("https://example.org/cert.cbor"),
+		PrivateKey: certtest.ReadPrivateKeyFile("../testdata/certs/test.key"),
+	})
 	vp := exchange.NewValidPeriod(
 		time.Date(2019, time.April, 22, 19, 30, 0, 0, time.UTC),
 		time.Date(2019, time.April, 29, 19, 30, 0, 0, time.UTC))
@@ -156,13 +153,11 @@ func TestFactory(t *testing.T) {
 }
 
 func TestRelativeCertURL(t *testing.T) {
-	factory := &exchange.Factory{
-		Version:      version.Version1b3,
-		MIRecordSize: 4096,
-		CertChain:    certtest.ReadCertChainFile("../testdata/certs/test.cbor"),
-		CertURL:      urlutil.MustParse("/cert.cbor"),
-		PrivateKey:   certtest.ReadPrivateKeyFile("../testdata/certs/test.key"),
-	}
+	factory := exchange.NewFactory(exchange.Config{
+		CertChain:  certtest.ReadCertChainFile("../testdata/certs/test.cbor"),
+		CertURL:    urlutil.MustParse("/cert.cbor"),
+		PrivateKey: certtest.ReadPrivateKeyFile("../testdata/certs/test.key"),
+	})
 	vp := exchange.NewValidPeriod(
 		time.Date(2019, time.April, 22, 19, 30, 0, 0, time.UTC),
 		time.Date(2019, time.April, 29, 19, 30, 0, 0, time.UTC))

--- a/packager_test.go
+++ b/packager_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/WICG/webpackage/go/signedexchange/version"
 	"github.com/google/webpackager"
 	"github.com/google/webpackager/exchange"
 	"github.com/google/webpackager/exchange/vprule"
@@ -49,13 +48,11 @@ func makeConfig(server *httptest.Server) webpackager.Config {
 			HTML: htmlproc.Config{TaskSet: tasks},
 		}),
 		ValidPeriodRule: vprule.FixedLifetime(7 * 24 * time.Hour),
-		ExchangeFactory: &exchange.Factory{
-			Version:      version.Version1b3,
-			MIRecordSize: 4096,
-			CertChain:    certtest.ReadCertChainFile("testdata/certs/test.cbor"),
-			CertURL:      urlutil.MustParse("https://example.org/cert.cbor"),
-			PrivateKey:   certtest.ReadPrivateKeyFile("testdata/certs/test.key"),
-		},
+		ExchangeFactory: exchange.NewFactory(exchange.Config{
+			CertChain:  certtest.ReadCertChainFile("testdata/certs/test.cbor"),
+			CertURL:    urlutil.MustParse("https://example.org/cert.cbor"),
+			PrivateKey: certtest.ReadPrivateKeyFile("testdata/certs/test.key"),
+		}),
 	}
 }
 


### PR DESCRIPTION
exchange.Factory was designed in early days of the developement and has interface inconsistent with other structs. This PR fixes it.