### PR TITLE
Cert Manager extension to support multiple certificates.

### DIFF
--- a/certchain/certmanager/disk_cache.go
+++ b/certchain/certmanager/disk_cache.go
@@ -63,9 +63,12 @@ func NewDiskCache(config DiskCacheConfig) *DiskCache {
 // d.OCSPPath are both non-empty and otherwise returns an error. Read returns
 // a multierror.Error (hashicorp/go-multierror) to report as many problems as
 // possible.
-func (d *DiskCache) Read() (*certchain.AugmentedChain, error) {
+func (d *DiskCache) Read(digest string) (*certchain.AugmentedChain, error) {
 	var errs *multierror.Error
 
+	// TODO(banaag): digest is currently unused and the behavior of the
+	// DiskCache continues to be for a single cert. Need to use digest here
+	// after initial PR review is complete.
 	if d.CertPath == "" {
 		errs = multierror.Append(errs, errEmptyCertPath)
 	}

--- a/certchain/certmanager/disk_cache_test.go
+++ b/certchain/certmanager/disk_cache_test.go
@@ -89,7 +89,7 @@ func TestDiskCache(t *testing.T) {
 	reader := func(id int) {
 		defer wg.Done()
 
-		ac, err := d.Read()
+		ac, err := d.Read("")
 		if err != nil {
 			t.Errorf("reader #%v: error with d.Read(): %v", id, err)
 			return

--- a/certchain/certmanager/manager_test.go
+++ b/certchain/certmanager/manager_test.go
@@ -16,7 +16,6 @@ package certmanager_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/webpackager/certchain/certmanager"
@@ -45,16 +44,15 @@ func TestManager(t *testing.T) {
 	{
 		t.Log("Started with augm0409")
 
-		select {
-		case got := <-cache.OnWrite:
-			if diff := cmp.Diff(augm0409, got, certComparer); diff != "" {
-				t.Errorf("cache mismatch (-want +got):\n%s", diff)
-			}
-		case <-time.After(defaultTimeout):
-			t.Error("cache timeout")
+		if cache.WaitForAvail(defaultTimeout) != waitSuccess {
+			t.Error("timed out waiting for cache avail\n")
+		}
+		got, _ := m.Cache.Read(augm0409.Digest)
+		if diff := cmp.Diff(augm0409, got, certComparer); diff != "" {
+			t.Errorf("cache mismatch (-want +got):\n%s", diff)
 		}
 
-		got := m.GetAugmentedChain()
+		got = m.GetAugmentedChain()
 		if diff := cmp.Diff(augm0409, got, certComparer); diff != "" {
 			t.Errorf("m.GetAugmentedChain() mismatch (-want +got):\n%s", diff)
 		}
@@ -64,16 +62,15 @@ func TestManager(t *testing.T) {
 	{
 		t.Log("Updated to augm0413")
 
-		select {
-		case got := <-cache.OnWrite:
-			if diff := cmp.Diff(augm0413, got, certComparer); diff != "" {
-				t.Errorf("cache mismatch (-want +got):\n%s", diff)
-			}
-		case <-time.After(defaultTimeout):
-			t.Error("cache timeout")
+		if cache.WaitForAvail(defaultTimeout) != waitSuccess {
+			t.Error("timed out waiting for cache avail\n")
+		}
+		got, _ := m.Cache.Read(augm0413.Digest)
+		if diff := cmp.Diff(augm0413, got, certComparer); diff != "" {
+			t.Errorf("cache mismatch (-want +got):\n%s", diff)
 		}
 
-		got := m.GetAugmentedChain()
+		got = m.GetAugmentedChain()
 		if diff := cmp.Diff(augm0413, got, certComparer); diff != "" {
 			t.Errorf("m.GetAugmentedChain() mismatch (-want +got):\n%s", diff)
 		}
@@ -83,16 +80,15 @@ func TestManager(t *testing.T) {
 	{
 		t.Log("Updated to augm0415")
 
-		select {
-		case got := <-cache.OnWrite:
-			if diff := cmp.Diff(augm0415, got, certComparer); diff != "" {
-				t.Errorf("cache mismatch (-want +got):\n%s", diff)
-			}
-		case <-time.After(defaultTimeout):
-			t.Error("cache timeout")
+		if cache.WaitForAvail(defaultTimeout) != waitSuccess {
+			t.Error("timed out waiting for cache avail\n")
+		}
+		got, _ := m.Cache.Read(augm0415.Digest)
+		if diff := cmp.Diff(augm0415, got, certComparer); diff != "" {
+			t.Errorf("cache mismatch (-want +got):\n%s", diff)
 		}
 
-		got := m.GetAugmentedChain()
+		got = m.GetAugmentedChain()
 		if diff := cmp.Diff(augm0415, got, certComparer); diff != "" {
 			t.Errorf("m.GetAugmentedChain() mismatch (-want +got):\n%s", diff)
 		}

--- a/certchain/certmanager/null_cache.go
+++ b/certchain/certmanager/null_cache.go
@@ -23,6 +23,10 @@ var NullCache Cache = &nullCache{}
 
 type nullCache struct{}
 
+func (*nullCache) Read(digest string) (*certchain.AugmentedChain, error) {
+	return nil, ErrNotFound
+}
+
 func (*nullCache) Write(ac *certchain.AugmentedChain) error {
 	return nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -49,6 +49,7 @@ func setupServer(www *httptest.Server) (*server.Server, string) {
 	certManager := certmanager.NewManager(certmanager.Config{
 		RawChainSource: &stubRawChainSource{ac.RawChain},
 		OCSPRespSource: &stubOCSPRespSource{ac.OCSPResp},
+		Cache:          newStubCache(),
 	})
 
 	s := server.NewServer(new(http.Server), server.Config{


### PR DESCRIPTION
For this commit, DiskCache continues to support single cert but I modified Cache and all its affected implementations and related tests.  After your review, if everything looks ok, I will extend DiskCache to support multi-cert (use digest).