### PR TITLE
FIXIT: Strip non-preload link headers.

### DIFF
--- a/processor/commonproc/preload.go
+++ b/processor/commonproc/preload.go
@@ -32,6 +32,11 @@ const headerKey = "Link"
 // the Link HTTP headers when the response is turned into a signed exchange.
 var ExtractPreloadHeaders processor.Processor = &extractPreloadHeaders{}
 
+// KeepNonPreloadLinkHeaders instruct the processor to include preload link
+// headers that don't have "preload" as the parameter.
+// TODO(banaag): put this in the TOML and propagate the config to the processor.
+var keepNonPreloadLinkHeaders = false
+
 // maxNumPreloads is the maximum number of preload links allowed by WebPackager.
 // This exists to satisfy: https://github.com/google/webpackager/blob/master/docs/cache_requirements.md.
 const maxNumPreloads = 20
@@ -59,7 +64,7 @@ func (*extractPreloadHeaders) Process(resp *exchange.Response) error {
 					resp.AddPreload(preload.NewPreloadForLink(link))
 					numPreloads++
 				}
-			} else {
+			} else if keepNonPreloadLinkHeaders {
 				resp.Header.Add(headerKey, link.String())
 			}
 		}

--- a/processor/commonproc/preload_test.go
+++ b/processor/commonproc/preload_test.go
@@ -76,9 +76,6 @@ func TestExtractPreloadHeaders(t *testing.T) {
 			),
 			wantPreloads: nil,
 			wantHeader: http.Header{
-				"Link": []string{
-					`<https://example.com/>;rel="start"`,
-				},
 				"Content-Type": []string{"text/html; charset=utf-8"},
 			},
 		},
@@ -98,9 +95,6 @@ func TestExtractPreloadHeaders(t *testing.T) {
 				pl(`<https://example.com/photo.jpg>;rel="preload";as="image"`),
 			},
 			wantHeader: http.Header{
-				"Link": []string{
-					`<https://example.com/>;rel="start"`,
-				},
 				"Content-Type": []string{"text/html; charset=utf-8"},
 			},
 		},
@@ -121,9 +115,6 @@ func TestExtractPreloadHeaders(t *testing.T) {
 				pl(`<https://example.com/photo.jpg>;rel="preload";as="image"`),
 			},
 			wantHeader: http.Header{
-				"Link": []string{
-					`<https://example.com/>;rel="start"`,
-				},
 				"Content-Type": []string{"text/html; charset=utf-8"},
 			},
 		},
@@ -180,9 +171,6 @@ func TestExtractPreloadHeaders(t *testing.T) {
 				pl(`<https://example.com/photo20.jpg>;rel="preload";as="image"`),
 			},
 			wantHeader: http.Header{
-				"Link": []string{
-					`<https://example.com/>;rel="start"`,
-				},
 				"Content-Type": []string{"text/html; charset=utf-8"},
 			},
 		},


### PR DESCRIPTION
Fixes #63