### PR TITLE
Fix webpkgserver so that it can read dummy OCSP in the cert cache. 

### DIFF
--- a/certchain/ocsp_response.go
+++ b/certchain/ocsp_response.go
@@ -53,6 +53,11 @@ var DummyOCSPResponse *OCSPResponse = &OCSPResponse{
 func ParseOCSPResponse(bytes []byte) (*OCSPResponse, error) {
 	resp, err := ocsp.ParseResponse(bytes, nil)
 	if err != nil {
+		if string(bytes) == string(DummyOCSPResponse.Raw) {
+			// This is necessary to serve a(n invalid) cert-chain+cbor in
+			// AllowTestCert mode.
+			return DummyOCSPResponse, nil
+		}
 		return nil, err
 	}
 	return &OCSPResponse{resp, bytes}, nil

--- a/certchain/ocsp_response_test.go
+++ b/certchain/ocsp_response_test.go
@@ -215,6 +215,13 @@ func TestOCSPResponseVerifyForRawChain_Dummy(t *testing.T) {
 	}
 }
 
+func TestOCSPResponseVerifyForOCSPDummy(t *testing.T) {
+	ocspResp := certchain.DummyOCSPResponse
+
+	if _, err := certchain.ParseOCSPResponse(ocspResp.Raw); err != nil {
+		t.Errorf("ParseOCSPResponse() = error(%q), want success", err)
+	}
+}
 func TestOCSPResponseVerifySXGCriteria_Success(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fix webpkgserver so that it can read dummy OCSP in the cert cache and render it properly from /webpkg/cert.
Fixes #67