### PR TITLE
Allow localhost testing without a TLS cert.

### DIFF
--- a/cmd/webpkgserver/webpkgserver.example.toml
+++ b/cmd/webpkgserver/webpkgserver.example.toml
@@ -83,10 +83,17 @@
   #
   # Generally you want to set the same value as Listen.CertPath, but you can
   # set a different value if you want to serve the certificate on a single
-  # domain or plan to host the certificate on your own server. Another usage
-  # is local testing: you can specify "https://localhost:8080/webpkg/cert" to
-  # have the browser fetch the certificate directly from webpkgserver running
-  # on your machine (you also need to set up TLS; see Listen.TLS.*).
+  # domain or plan to host the certificate on your own server.
+  #
+  # For local testing:
+  #   - If you have specified TLS.PEMFile and TLS.KeyFile, then you can you can
+  #     specify "https://localhost:8080/webpkg/cert" here, to have the browser
+  #     fetch the certificate directly from webpkgserver running on your
+  #     machine.
+  #   - Otherwise, you can specify "data:" here, and webpkgserver
+  #     will build data: cert-urls that are valid on http://localhost signed
+  #     exchanges. Note that data: cert-urls will not meet Google SXG cache
+  #     requirements.
   #CertURLBase = '/webpkg/cert'
 
   # The validity-url of signed exchanges. webpkgserver sets the same URL to

--- a/cmd/webpkgserver/webpkgserver.example.toml
+++ b/cmd/webpkgserver/webpkgserver.example.toml
@@ -92,8 +92,9 @@
   #     machine.
   #   - Otherwise, you can specify "data:" here, and webpkgserver
   #     will build data: cert-urls that are valid on http://localhost signed
-  #     exchanges. Note that data: cert-urls will not meet Google SXG cache
-  #     requirements.
+  #     exchanges. This will not work in production; these data: URLs will not
+  #     include an updated OCSP response, and otherwise do not meet Google SXG
+  #     cache requirements.
   #CertURLBase = '/webpkg/cert'
 
   # The validity-url of signed exchanges. webpkgserver sets the same URL to

--- a/docs/cache_requirements.md
+++ b/docs/cache_requirements.md
@@ -11,6 +11,7 @@ following requirements are met.
 The Google SXG cache sets these requirements in addition to the ones set by the
 [SXG spec][]:
  - The signed `fallback URL` must equal the URL at which the SXG was served.
+ - The signed `cert-url` must be `https`.
  - The signature header must contain only:
    - One parameterised identifier.
    - Parameter values of type string, binary, or identifier.

--- a/exchange/factory.go
+++ b/exchange/factory.go
@@ -32,7 +32,7 @@ type Factory struct {
 
 // FactoryProvider provides Factory.
 type FactoryProvider interface {
-	Get() *Factory
+	Get() (*Factory, error)
 }
 
 // NewFactory creates and initializes a new Factory. It panics if c.CertChain
@@ -91,4 +91,4 @@ func (fty *Factory) Verify(e *signedexchange.Exchange, date time.Time) ([]byte, 
 
 // Get returns fty. It implements FactoryProvider and allows Factory to be
 // set directory to ExchangeFactory in webpackager.Config.
-func (fty *Factory) Get() *Factory { return fty }
+func (fty *Factory) Get() (*Factory, error) { return fty, nil }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -116,7 +116,11 @@ func verifyExchange(t *testing.T, pkg *webpackager.Packager, url string, date ti
 		return
 	}
 
-	if _, err := pkg.ExchangeFactory.Get().Verify(r.Exchange, date); err != nil {
+	ef, err := pkg.ExchangeFactory.Get()
+	if err != nil {
+		t.Errorf("ExchangeFactory.Get() = error(%q), want success", err)
+	}
+	if _, err := ef.Verify(r.Exchange, date); err != nil {
 		t.Errorf("Verify(sxg[%q]) = error(%q), want success", url, err)
 	}
 	if got := strings.Join(r.Exchange.ResponseHeaders["Link"], ","); got != link {

--- a/packager.go
+++ b/packager.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/google/webpackager/resource"
-        "golang.org/x/xerrors"
+	"golang.org/x/xerrors"
 )
 
 // Packager implements the control flow of Web Packager.

--- a/packager.go
+++ b/packager.go
@@ -15,6 +15,7 @@
 package webpackager
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -62,7 +63,10 @@ func (pkg *Packager) Run(url *url.URL, sxgDate time.Time) error {
 // RunForRequest uses req directly: RequestTweaker mutates req; FetchClient
 // sends req to retrieve the HTTP response.
 func (pkg *Packager) RunForRequest(req *http.Request, sxgDate time.Time) error {
-	runner := newTaskRunner(pkg, sxgDate)
+	runner, err := newTaskRunner(pkg, sxgDate)
+	if err != nil {
+		return fmt.Errorf("packaging: %w", err)
+	}
 	runner.run(nil, req, resource.NewResource(req.URL))
 	return runner.err()
 }

--- a/packager.go
+++ b/packager.go
@@ -15,12 +15,12 @@
 package webpackager
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/google/webpackager/resource"
+        "golang.org/x/xerrors"
 )
 
 // Packager implements the control flow of Web Packager.
@@ -65,7 +65,7 @@ func (pkg *Packager) Run(url *url.URL, sxgDate time.Time) error {
 func (pkg *Packager) RunForRequest(req *http.Request, sxgDate time.Time) error {
 	runner, err := newTaskRunner(pkg, sxgDate)
 	if err != nil {
-		return fmt.Errorf("packaging: %w", err)
+		return xerrors.Errorf("packaging: %w", err)
 	}
 	runner.run(nil, req, resource.NewResource(req.URL))
 	return runner.err()

--- a/packager_test.go
+++ b/packager_test.go
@@ -301,9 +301,13 @@ func TestSubresourceErrorsKeepPreloads(t *testing.T) {
 	defer server.Close()
 
 	cfg := makeConfig(server)
-	cfg.ExchangeFactory.Get().KeepNonSXGPreloads = true
+	ef, err := cfg.ExchangeFactory.Get()
+	if err != nil {
+		t.Errorf("ExchangeFactory.Get() = error(%q), want success", err)
+	}
+	ef.KeepNonSXGPreloads = true
 	pkg := webpackager.NewPackager(cfg)
-	err := pkg.Run(urlutil.MustParse("https://example.org/hello.html"), date)
+	err = pkg.Run(urlutil.MustParse("https://example.org/hello.html"), date)
 
 	// err should indicate all invalid subresources.
 	verifyErrorURLs(t, err, []string{

--- a/server/exchange.go
+++ b/server/exchange.go
@@ -18,13 +18,13 @@ import (
 	"bytes"
 	"crypto"
 	"encoding/base64"
-	"fmt"
 	"net/url"
 	"path"
 
 	"github.com/WICG/webpackage/go/signedexchange/version"
 	"github.com/google/webpackager/certchain/certmanager"
 	"github.com/google/webpackager/exchange"
+        "golang.org/x/xerrors"
 )
 
 // ExchangeMetaFactory is an exchange.FactoryProvider designed to be used
@@ -82,7 +82,7 @@ func (e *ExchangeMetaFactory) Get() (*exchange.Factory, error) {
 	if e.CertURLBase.Scheme == "data" {
 		var cbor bytes.Buffer
 		if err := chain.WriteCBOR(&cbor); err != nil {
-			return nil, fmt.Errorf("error creating data: cert-url: %w", err)
+			return nil, xerrors.Errorf("error creating data: cert-url: %w", err)
 		}
 		// The example in https://tools.ietf.org/html/rfc2397 has
 		// slashes, and the examples in

--- a/server/exchange.go
+++ b/server/exchange.go
@@ -24,7 +24,7 @@ import (
 	"github.com/WICG/webpackage/go/signedexchange/version"
 	"github.com/google/webpackager/certchain/certmanager"
 	"github.com/google/webpackager/exchange"
-        "golang.org/x/xerrors"
+	"golang.org/x/xerrors"
 )
 
 // ExchangeMetaFactory is an exchange.FactoryProvider designed to be used

--- a/server/exchange.go
+++ b/server/exchange.go
@@ -15,7 +15,9 @@
 package server
 
 import (
+	"bytes"
 	"crypto"
+	"encoding/base64"
 	"net/url"
 	"path"
 
@@ -75,15 +77,34 @@ func NewExchangeMetaFactory(c ExchangeConfig) *ExchangeMetaFactory {
 func (e *ExchangeMetaFactory) Get() *exchange.Factory {
 	chain := e.CertManager.GetAugmentedChain()
 
-	// Use path.Join so the last path element in e.CertURLBase is kept
-	// whether or not it has the trailing slash.
-	urlPath := path.Join(e.CertURLBase.Path, chain.Digest)
+	var certURL *url.URL
+	if e.CertURLBase.Scheme == "data" {
+		var cbor bytes.Buffer
+		if err := chain.WriteCBOR(&cbor); err != nil {
+			// TODO: Don't panic.
+			panic(err)
+		}
+		// The example in https://tools.ietf.org/html/rfc2397 has
+		// slashes, and the examples in
+		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+		// have padding chars, so I think we want StdEncoding.
+		encoded := base64.StdEncoding.EncodeToString(cbor.Bytes())
+		certURL = &url.URL{
+			Scheme: "data",
+			Opaque: "application/cert-chain+cbor;base64," + encoded,
+		}
+	} else {
+		// Use path.Join so the last path element in e.CertURLBase is kept
+		// whether or not it has the trailing slash.
+		urlPath := path.Join(e.CertURLBase.Path, chain.Digest)
+		certURL = e.CertURLBase.ResolveReference(&url.URL{Path: urlPath})
+	}
 
 	config := exchange.Config{
 		Version:            e.Version,
 		MIRecordSize:       e.MIRecordSize,
 		CertChain:          chain,
-		CertURL:            e.CertURLBase.ResolveReference(&url.URL{Path: urlPath}),
+		CertURL:            certURL,
 		PrivateKey:         e.PrivateKey,
 		KeepNonSXGPreloads: e.KeepNonSXGPreloads,
 	}

--- a/server/exchange.go
+++ b/server/exchange.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto"
 	"encoding/base64"
+	"fmt"
 	"net/url"
 	"path"
 
@@ -74,15 +75,14 @@ func NewExchangeMetaFactory(c ExchangeConfig) *ExchangeMetaFactory {
 
 // Get returns a new exchange.Factory set with the current AugmentedChain
 // from e.CertManager.
-func (e *ExchangeMetaFactory) Get() *exchange.Factory {
+func (e *ExchangeMetaFactory) Get() (*exchange.Factory, error) {
 	chain := e.CertManager.GetAugmentedChain()
 
 	var certURL *url.URL
 	if e.CertURLBase.Scheme == "data" {
 		var cbor bytes.Buffer
 		if err := chain.WriteCBOR(&cbor); err != nil {
-			// TODO: Don't panic.
-			panic(err)
+			return nil, fmt.Errorf("error creating data: cert-url: %w", err)
 		}
 		// The example in https://tools.ietf.org/html/rfc2397 has
 		// slashes, and the examples in
@@ -108,5 +108,5 @@ func (e *ExchangeMetaFactory) Get() *exchange.Factory {
 		PrivateKey:         e.PrivateKey,
 		KeepNonSXGPreloads: e.KeepNonSXGPreloads,
 	}
-	return exchange.NewFactory(config)
+	return exchange.NewFactory(config), nil
 }

--- a/server/tomlconfig/verify_test.go
+++ b/server/tomlconfig/verify_test.go
@@ -90,7 +90,7 @@ func TestVerifyServePath_Error(t *testing.T) {
 	}
 }
 
-func TestVerifyURL(t *testing.T) {
+func TestVerifyValidityURL(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
@@ -115,14 +115,14 @@ func TestVerifyURL(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if err := verifyURL(test.url); err != nil {
-				t.Errorf("verifyURL(%q) = error(%q), want success", test.url, err)
+			if err := verifyValidityURL(test.url); err != nil {
+				t.Errorf("verifyValidityURL(%q) = error(%q), want success", test.url, err)
 			}
 		})
 	}
 }
 
-func TestVerifyURL_Error(t *testing.T) {
+func TestVerifyValidityURL_Error(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
@@ -167,9 +167,16 @@ func TestVerifyURL_Error(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if err := verifyURL(test.url); err == nil {
-				t.Errorf("verifyURL(%q) = success, want error", test.url)
+			if err := verifyValidityURL(test.url); err == nil {
+				t.Errorf("verifyValidityURL(%q) = success, want error", test.url)
 			}
 		})
+	}
+}
+
+func TestVerifyCertURL(t *testing.T) {
+	testURL := "data:"
+	if err := verifyCertURL(testURL); err != nil {
+		t.Errorf("verifyCertURL(%q) = error(%q), want success", testURL, err)
 	}
 }

--- a/task.go
+++ b/task.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/webpackager/exchange"
 	"github.com/google/webpackager/resource"
 	multierror "github.com/hashicorp/go-multierror"
+        "golang.org/x/xerrors"
 )
 
 var (
@@ -52,7 +53,7 @@ type packagerTaskRunner struct {
 func newTaskRunner(p *Packager, date time.Time) (*packagerTaskRunner, error) {
 	ef, err := p.ExchangeFactory.Get()
 	if err != nil {
-		return nil, fmt.Errorf("creating task runner: %w", err)
+		return nil, xerrors.Errorf("creating task runner: %w", err)
 	}
 	return &packagerTaskRunner{
 		p,

--- a/task.go
+++ b/task.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/webpackager/exchange"
 	"github.com/google/webpackager/resource"
 	multierror "github.com/hashicorp/go-multierror"
-        "golang.org/x/xerrors"
+	"golang.org/x/xerrors"
 )
 
 var (

--- a/task.go
+++ b/task.go
@@ -49,14 +49,18 @@ type packagerTaskRunner struct {
 	active     map[string]bool // Keyed by URLs.
 }
 
-func newTaskRunner(p *Packager, date time.Time) *packagerTaskRunner {
+func newTaskRunner(p *Packager, date time.Time) (*packagerTaskRunner, error) {
+	ef, err := p.ExchangeFactory.Get()
+	if err != nil {
+		return nil, fmt.Errorf("creating task runner: %w", err)
+	}
 	return &packagerTaskRunner{
 		p,
 		date,
-		p.ExchangeFactory.Get(),
+		ef,
 		new(multierror.Error),
 		make(map[string]bool),
-	}
+	}, nil
 }
 
 func (runner *packagerTaskRunner) err() error {


### PR DESCRIPTION
Enable a `CertURLBase = "data:"` option that allows http://localhost SXGs to
display in the browser.

I tested the error plumbing by injecting a fake error in ExchangeMetaFactory.Get().

/cc @khempenius