### PR TITLE
Inline content negotiation note into SXG item

### DIFF
--- a/cmd/webpkgserver/README.md
+++ b/cmd/webpkgserver/README.md
@@ -187,7 +187,7 @@ The setup is similar to [AMP Packager][]:
 *   Determine if the request is for a signed exchange, based on the `Accept`
     header. See the [Content Negotiation](#content-negotiation) section for
     further details on how to do this.  If the request is for a signed
-    exchange rewrite the URL by prepending `/priv/doc/` and forward the
+    exchange, rewrite the URL by prepending `/priv/doc/` and forward the
     request. In NGINX the directive would look like:
 
     ```

--- a/cmd/webpkgserver/README.md
+++ b/cmd/webpkgserver/README.md
@@ -184,7 +184,9 @@ The setup is similar to [AMP Packager][]:
     }
     ```
 
-*   If the request is requesting for a signed exchange rewrite the URL by
+*   Determine if the request is for a signed exchange, based on the `Accept`
+    header. See the Content Negotiation section for further details on how to
+    do this.  If the request for a signed exchange rewrite the URL by
     prepending `/priv/doc/` and forward the request. In NGINX the directive
     would look like:
 
@@ -214,9 +216,6 @@ The setup is similar to [AMP Packager][]:
 [misleading content]: https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#section-6.1.2
 
 *   Every 90 days or sooner, renew your SXG cert and restart webpkgserver.
-
-*   Content negotiation setup should be based on the `Accept` header. See the
-    section on Content Negotiation for further details.
 
 ## Content Negotiation
 

--- a/cmd/webpkgserver/README.md
+++ b/cmd/webpkgserver/README.md
@@ -185,10 +185,10 @@ The setup is similar to [AMP Packager][]:
     ```
 
 *   Determine if the request is for a signed exchange, based on the `Accept`
-    header. See the Content Negotiation section for further details on how to
-    do this.  If the request for a signed exchange rewrite the URL by
-    prepending `/priv/doc/` and forward the request. In NGINX the directive
-    would look like:
+    header. See the [Content Negotiation](#content-negotiation) section for
+    further details on how to do this.  If the request is for a signed
+    exchange rewrite the URL by prepending `/priv/doc/` and forward the
+    request. In NGINX the directive would look like:
 
     ```
     proxy_pass http://127.0.0.1:8080/priv/doc/https://example.com$request_uri;


### PR DESCRIPTION
Move the content negotiation requirement into the item about forwarding SXG
requests, where it is most relevant.

/cc @khempenius