### PR TITLE
Reduce max length to 200 chars

### DIFF
--- a/docs/supported_media.md
+++ b/docs/supported_media.md
@@ -30,7 +30,7 @@ User agents should ignore this meta tag.
 A `<meta>` element, as a child of the document's `<head>` element, where its
 `name=` is "supported-media", and its `content=` is a well-formed [level 3
 media query list](https://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/)
-in the same character encoding as the page, less than 1024 characters, and
+in the same character encoding as the page, less than 200 characters, and
 containing only the below supported media types and features:
 
  - `all`


### PR DESCRIPTION
From a brief survey
(https://gist.github.com/twifkak/457310e9fe0ee89f068a0cadeaf94ba9), the max
length in common media queries is 178, so this leaves some room for growth,
while helping reduce potential byte cost to referring pages. It is easier to
increase this number than decrease it, so let's start conservatively.