### PR TITLE
Allow cross-origin preloads within webpkgserver.

### DIFF
--- a/packager_test.go
+++ b/packager_test.go
@@ -116,10 +116,10 @@ func TestCrossDomain(t *testing.T) {
 		"https://example.com/style.css",
 	})
 	// An exchange is generated without preloading.
-	verifyExchange(t, pkg, "https://example.org/hello.html", date,
+	verifyExchange(t, pkg, "https://example.org/hello.html", date, fmt.Sprint(
 		`<https://example.com/style.css>;rel="allowed-alt-sxg";`+
-			`header-integrity="sha256-+Xd20Pyxhd3oSvNo2ucj9gdj7ZkHavIaDGkucYF76J8=",`+
-		`<https://example.com/style.css>;rel="preload";as="style"`)
+			`header-integrity="sha256-+Xd20Pyxhd3oSvNo2ucj9gdj7ZkHavIaDGkucYF76J8=",`,
+		`<https://example.com/style.css>;rel="preload";as="style"`))
 }
 
 func TestDupResource(t *testing.T) {

--- a/packager_test.go
+++ b/packager_test.go
@@ -113,9 +113,13 @@ func TestCrossDomain(t *testing.T) {
 	// includes RequireSameOrigin.
 	verifyRequests(t, pkg, []string{
 		"https://example.org/hello.html",
+		"https://example.com/style.css",
 	})
 	// An exchange is generated without preloading.
-	verifyExchange(t, pkg, "https://example.org/hello.html", date, "")
+	verifyExchange(t, pkg, "https://example.org/hello.html", date,
+		`<https://example.com/style.css>;rel="allowed-alt-sxg";`+
+			`header-integrity="sha256-+Xd20Pyxhd3oSvNo2ucj9gdj7ZkHavIaDGkucYF76J8=",`+
+		`<https://example.com/style.css>;rel="preload";as="style"`)
 }
 
 func TestDupResource(t *testing.T) {

--- a/processor/complexproc/complexproc.go
+++ b/processor/complexproc/complexproc.go
@@ -57,7 +57,6 @@ var (
 	}
 	// EssentialPostprocessors contain always-run postprocessors.
 	EssentialPostprocessors = processor.SequentialProcessor{
-		commonproc.ApplySameOriginPolicy,
 		commonproc.ContentTypeProcessor,
 		commonproc.RemoveUncachedHeaders,
 	}


### PR DESCRIPTION
Allow SXGs to preload subresources from a different origin, as long as the
subresource URL is served by webpkgserver, and matches the [SXG.Cert] and
[[Sign]] sections of the config. No documentation to update, as the previous
same-origin limitation was not documented.

This follows from the cache support documented in #75. A future commit will add
support for preloading SXGs served from outside of this webpkgserver config.

Addresses http://b/152447215.