### PR TITLE
Remove allow-sxg-certs-without-extension

### DIFF
--- a/cmd/webpkgserver/README.md
+++ b/cmd/webpkgserver/README.md
@@ -67,10 +67,6 @@ way.
 
 [Let's Encrypt]: https://letsencrypt.org/
 
-Chrome can be configured to allow these invalid certificates with the Allow
-Signed HTTP Exchange certificates without extension experiment:
-chrome://flags/#allow-sxg-certs-without-extension.
-
 You can run Chrome with these command line flags to ignore certificate errors:
 
 ```bash


### PR DESCRIPTION
It no longer exists, and is covered by the --ignore-certificate-errors flag anyhow.

/cc @antiphoton