### PR TITLE
Convert URL mismatch error into a warning log.

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -163,7 +163,7 @@ func (h *Handler) handleDocImpl(w http.ResponseWriter, req *http.Request, signUR
 			return
 		}
 		if xerrors.Is(err, fetch.ErrURLMismatch) {
-			replyClientError(w, err)
+			replyClientErrorSilent(w)
 			return
 		}
 		if err != nil {

--- a/server/reply.go
+++ b/server/reply.go
@@ -41,6 +41,10 @@ func replyClientError(w http.ResponseWriter, err error) {
 	replyError(w, http.StatusBadRequest)
 }
 
+func replyClientErrorSilent(w http.ResponseWriter) {
+	replyError(w, http.StatusBadRequest)
+}
+
 func replyError(w http.ResponseWriter, code int) {
 	http.Error(w, fmt.Sprintf("%d %s", code, http.StatusText(code)), code)
 }


### PR DESCRIPTION
Fixes #90 