### PR TITLE
Change disk_cache implementations to return ErrNotFound when cert or ocsp is not found. 

### DIFF
--- a/certchain/certmanager/multicert_disk_cache.go
+++ b/certchain/certmanager/multicert_disk_cache.go
@@ -117,7 +117,9 @@ func (d *MultiCertDiskCache) Read(digest string) (*certchain.AugmentedChain, err
 		errs = multierror.Append(errs, ErrNotFound)
 	}
 	ocspResp, err := certchainutil.ReadOCSPRespFile(ocsp)
-	errs = multierror.Append(errs, err)
+	if err != nil {
+		errs = multierror.Append(errs, ErrNotFound)
+	}
 
 	var augChain *certchain.AugmentedChain
 	if errs.ErrorOrNil() == nil {

--- a/certchain/certmanager/multicert_disk_cache.go
+++ b/certchain/certmanager/multicert_disk_cache.go
@@ -113,7 +113,9 @@ func (d *MultiCertDiskCache) Read(digest string) (*certchain.AugmentedChain, err
 	cert := path.Join(d.CertDir, digest+".pem")
 	ocsp := path.Join(d.CertDir, digest+".ocsp")
 	rawChain, err := certchainutil.ReadRawChainFile(cert)
-	errs = multierror.Append(errs, err)
+	if err != nil {
+		errs = multierror.Append(errs, ErrNotFound)
+	}
 	ocspResp, err := certchainutil.ReadOCSPRespFile(ocsp)
 	errs = multierror.Append(errs, err)
 

--- a/certchain/certmanager/multicert_disk_cache.go
+++ b/certchain/certmanager/multicert_disk_cache.go
@@ -115,10 +115,12 @@ func (d *MultiCertDiskCache) Read(digest string) (*certchain.AugmentedChain, err
 	rawChain, err := certchainutil.ReadRawChainFile(cert)
 	if err != nil {
 		errs = multierror.Append(errs, ErrNotFound)
+		errs = multierror.Append(errs, err)
 	}
 	ocspResp, err := certchainutil.ReadOCSPRespFile(ocsp)
 	if err != nil {
 		errs = multierror.Append(errs, ErrNotFound)
+		errs = multierror.Append(errs, err)
 	}
 
 	var augChain *certchain.AugmentedChain

--- a/certchain/certmanager/singlecert_disk_cache.go
+++ b/certchain/certmanager/singlecert_disk_cache.go
@@ -85,7 +85,9 @@ func (d *SingleCertDiskCache) ReadLatest() (*certchain.AugmentedChain, error) {
 		errs = multierror.Append(errs, ErrNotFound)
 	}
 	ocspResp, err := certchainutil.ReadOCSPRespFile(d.OCSPPath)
-	errs = multierror.Append(errs, err)
+	if err != nil {
+		errs = multierror.Append(errs, ErrNotFound)
+	}
 
 	var augChain *certchain.AugmentedChain
 	if errs.ErrorOrNil() == nil {

--- a/certchain/certmanager/singlecert_disk_cache.go
+++ b/certchain/certmanager/singlecert_disk_cache.go
@@ -83,10 +83,12 @@ func (d *SingleCertDiskCache) ReadLatest() (*certchain.AugmentedChain, error) {
 	rawChain, err := certchainutil.ReadRawChainFile(d.CertPath)
 	if err != nil {
 		errs = multierror.Append(errs, ErrNotFound)
+		errs = multierror.Append(errs, err)
 	}
 	ocspResp, err := certchainutil.ReadOCSPRespFile(d.OCSPPath)
 	if err != nil {
 		errs = multierror.Append(errs, ErrNotFound)
+		errs = multierror.Append(errs, err)
 	}
 
 	var augChain *certchain.AugmentedChain

--- a/certchain/certmanager/singlecert_disk_cache.go
+++ b/certchain/certmanager/singlecert_disk_cache.go
@@ -81,7 +81,9 @@ func (d *SingleCertDiskCache) ReadLatest() (*certchain.AugmentedChain, error) {
 	}
 
 	rawChain, err := certchainutil.ReadRawChainFile(d.CertPath)
-	errs = multierror.Append(errs, err)
+	if err != nil {
+		errs = multierror.Append(errs, ErrNotFound)
+	}
 	ocspResp, err := certchainutil.ReadOCSPRespFile(d.OCSPPath)
 	errs = multierror.Append(errs, err)
 


### PR DESCRIPTION
Change disk_cache implementations to return ErrNotFound when cert or ocsp is not found. Fixes #97.