### PR TITLE
Add note to TOML regarding retries during failure case.

### DIFF
--- a/cmd/webpkgserver/webpkgserver.example.toml
+++ b/cmd/webpkgserver/webpkgserver.example.toml
@@ -215,8 +215,8 @@
 #
 # In the event that cert renewal fails and requires user intervention on the
 # user's CA account packager will continue to request new certificates in the
-# background which will result in multiple orders possibliy queueing up in the
-# user's CA account. Make sure to clear all those orders as you it may result in
+# background which will result in multiple orders possibly queueing up in the
+# user's CA account. Make sure to clear all those orders as it may result in
 # multiple certificate charges. It's also important that you make sure you are
 # notified (by email) when such events occur so that you can resolve appropriately.
 #

--- a/cmd/webpkgserver/webpkgserver.example.toml
+++ b/cmd/webpkgserver/webpkgserver.example.toml
@@ -213,6 +213,13 @@
 # experience with people using it out in the wild, we will gradually move it to
 # the PRODUCTION stage.
 #
+# In the event that cert renewal fails and requires user intervention on the
+# user's CA account packager will continue to request new certificates in the
+# background which will result in multiple orders possibliy queueing up in the
+# user's CA account. Make sure to clear all those orders as you it may result in
+# multiple certificate charges. It's also important that you make sure you are
+# notified (by email) when such events occur so that you can resolve appropriately.
+#
 # Configure ACME, which allows the webpkgserver to automatically renew Signed
 # Exchange certificates.
 #


### PR DESCRIPTION
Add a note for cases when packager keeps retrying to retrieve new cert when there's a scenario that requires user intervention on their CA account.