### PR TITLE
Document temporary disallow of `Vary: Cookie`

### DIFF
--- a/docs/cache_requirements.md
+++ b/docs/cache_requirements.md
@@ -50,6 +50,7 @@ The Google SXG cache sets these requirements in addition to the ones set by the
  - The `link` header must not be present on subresources, i.e. SXGs that are
    themselves preloaded from other SXGs.
  - There must not be a signed `variant-key-04` or `variants-04` header.
+ - The `vary` header, if present, must not contain `cookie`.
  - The signature's lifetime (`expires` minutes request time) must be >= 120
    seconds.
  - The SXG must be no larger than 8 megabytes.


### PR DESCRIPTION
This will be re-allowed soon, after the minimum Chromium requirement is increased to M98 to include https://crbug.com/1250532.